### PR TITLE
front-end:  Manager can seat a table

### DIFF
--- a/client/components/FloorPlan.jsx
+++ b/client/components/FloorPlan.jsx
@@ -6,12 +6,17 @@ import TableButton from './TableButton';
 export default class FloorPlan extends React.Component {
   constructor(props) {
     super(props);
+    this.updateTables = this.updateTables.bind(this);
     this.state = {
       tables: []
     };
   }
 
   componentDidMount() {
+    this.updateTables();
+  }
+
+  updateTables() {
     fetch('/api/restaurant')
       .then(response => response.json())
       .then(data => {

--- a/client/components/FloorPlan.jsx
+++ b/client/components/FloorPlan.jsx
@@ -67,7 +67,15 @@ export default class FloorPlan extends React.Component {
       }
       const children = <div>{`T${tableId}`}<div>{this.parseTimeSeated(timeSeated)}</div></div>;
       return (
-        <TableButton key={tableId} tableData={table} color={color} text={children} status={table}/>
+        <TableButton
+          key={tableId}
+          tableData={table}
+          color={color}
+          text={children}
+          status={table}
+          viewDialog={this.props.viewDialog}
+          dialogOpen={this.props.dialogOpen}
+        />
       );
     });
 

--- a/client/components/FloorPlan.jsx
+++ b/client/components/FloorPlan.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Grid from '@material-ui/core/Grid';
 import Box from '@material-ui/core/Box';
-import { TableButton } from './TableButton';
+import TableButton from './TableButton';
 
 export default class FloorPlan extends React.Component {
   constructor(props) {
@@ -22,57 +22,13 @@ export default class FloorPlan extends React.Component {
       });
   }
 
-  parseTimeSeated(timeSeated) {
-    if (timeSeated) {
-      const splitTime = timeSeated.split('T');
-      const furtherSplit = splitTime[1].split(':');
-      let [hours, minutes] = furtherSplit;
-      hours = parseInt(hours, 10);
-      // this is for timezone.  Idk why 5 works
-      hours += 5;
-      if (hours > 12) {
-        hours -= 12;
-      }
-      let amPM = 'AM';
-      if (hours > 11) {
-        amPM = 'PM';
-      }
-      if (hours === 24 || hours === 0) {
-        hours = 12;
-        amPM = 'AM';
-      } else if (hours > 12) {
-        hours -= 12;
-      }
-      return `${hours}:${minutes} ${amPM}`;
-    }
-    return '';
-  }
-
   render() {
     const { tables } = this.state;
     const tableList = tables.map(table => {
-      const { tableId, tableStatus, timeSeated } = table;
-      let color;
-      switch (tableStatus) {
-        case (0):
-          color = 'default';
-          break;
-        case (1):
-          color = 'primary';
-          break;
-        case (2):
-          color = 'secondary';
-          break;
-        default:
-      }
-      const children = <div>{`T${tableId}`}<div>{this.parseTimeSeated(timeSeated)}</div></div>;
       return (
         <TableButton
-          key={tableId}
+          key={table.tableId}
           tableData={table}
-          color={color}
-          text={children}
-          status={table}
           viewDialog={this.props.viewDialog}
           dialogOpen={this.props.dialogOpen}
         />

--- a/client/components/FloorPlan.jsx
+++ b/client/components/FloorPlan.jsx
@@ -6,30 +6,22 @@ import TableButton from './TableButton';
 export default class FloorPlan extends React.Component {
   constructor(props) {
     super(props);
-    this.updateTables = this.updateTables.bind(this);
     this.state = {
-      tables: []
+      floorPlan: []
     };
   }
 
-  componentDidMount() {
-    this.updateTables();
-  }
-
-  updateTables() {
-    fetch('/api/restaurant')
-      .then(response => response.json())
-      .then(data => {
-        this.setState({ tables: data });
-      })
-      .catch(error => {
-        console.error(error);
+  componentDidUpdate(prevProps) {
+    if (this.props.floorPlan !== prevProps.floorPlan) {
+      this.setState({
+        floorPlan: this.props.floorPlan
       });
+    }
   }
 
   render() {
-    const { tables } = this.state;
-    const tableList = tables.map(table => {
+    const { floorPlan } = this.state;
+    const tableList = floorPlan.map(table => {
       return (
         <TableButton
           key={table.tableId}

--- a/client/components/TableButton.jsx
+++ b/client/components/TableButton.jsx
@@ -3,7 +3,7 @@ import { withStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
 
-const styles = {
+const useStyles = theme => ({
   root: {
     border: 0,
     borderRadius: '40px',
@@ -11,20 +11,60 @@ const styles = {
     width: '80px',
     height: '80px'
   }
-};
+});
 
-const makeStyled = withStyles(styles);
+class TableButton extends React.Component {
 
-function CustomButton(props) {
-  const { classes } = props;
-  return (
-    <Grid item xs={3}>
-      <Button variant="contained" color={props.color} className={classes.root}>
-        {props.text}
-      </Button>
-    </Grid>
+  parseTimeSeated(timeSeated) {
+    if (timeSeated) {
+      const splitTime = timeSeated.split('T');
+      const furtherSplit = splitTime[1].split(':');
+      let [hours, minutes] = furtherSplit;
+      hours = parseInt(hours, 10);
+      // this is for timezone.  Idk why 5 works
+      hours += 5;
+      if (hours > 12) {
+        hours -= 12;
+      }
+      let amPM = 'AM';
+      if (hours > 11) {
+        amPM = 'PM';
+      }
+      if (hours === 24 || hours === 0) {
+        hours = 12;
+        amPM = 'AM';
+      } else if (hours > 12) {
+        hours -= 12;
+      }
+      return `${hours}:${minutes} ${amPM}`;
+    }
+    return '';
+  }
 
-  );
+  render() {
+    const { classes } = this.props;
+    const { tableId, tableStatus, timeSeated } = this.props.tableData;
+    let color;
+    switch (tableStatus) {
+      case (0):
+        color = 'default';
+        break;
+      case (1):
+        color = 'primary';
+        break;
+      case (2):
+        color = 'secondary';
+        break;
+      default:
+    }
+    return (
+      <Grid item xs={3}>
+        <Button variant="contained" color={color} className={classes.root}>
+          <div>{`T${tableId}`}<div>{this.parseTimeSeated(timeSeated)}</div></div>
+        </Button>
+      </Grid>
+    );
+  }
 }
 
-export const TableButton = makeStyled(CustomButton);
+export default withStyles(useStyles)(TableButton);

--- a/client/components/TableButton.jsx
+++ b/client/components/TableButton.jsx
@@ -46,7 +46,6 @@ class TableButton extends React.Component {
   }
 
   handleClick(e) {
-    console.log(e.currentTarget.id);
     this.props.viewDialog(true, this.props.tableData);
   }
 

--- a/client/components/TableButton.jsx
+++ b/client/components/TableButton.jsx
@@ -14,6 +14,10 @@ const useStyles = theme => ({
 });
 
 class TableButton extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleClick = this.handleClick.bind(this);
+  }
 
   parseTimeSeated(timeSeated) {
     if (timeSeated) {
@@ -41,6 +45,11 @@ class TableButton extends React.Component {
     return '';
   }
 
+  handleClick(e) {
+    console.log(e.currentTarget.id);
+    this.props.viewDialog(true, this.props.tableData);
+  }
+
   render() {
     const { classes } = this.props;
     const { tableId, tableStatus, timeSeated } = this.props.tableData;
@@ -59,7 +68,7 @@ class TableButton extends React.Component {
     }
     return (
       <Grid item xs={3}>
-        <Button variant="contained" color={color} className={classes.root}>
+        <Button id={`T${tableId}`} onClick={this.handleClick} variant="contained" color={color} className={classes.root}>
           <div>{`T${tableId}`}<div>{this.parseTimeSeated(timeSeated)}</div></div>
         </Button>
       </Grid>

--- a/client/components/TablePopUp.jsx
+++ b/client/components/TablePopUp.jsx
@@ -12,8 +12,7 @@ export default class TablePopUp extends React.Component {
     this.handleClose = this.handleClose.bind(this);
     this.handleClick = this.handleClick.bind(this);
     this.state = {
-      isOpen: false,
-      isSeatable: true
+      isOpen: false
     };
   }
 
@@ -23,17 +22,8 @@ export default class TablePopUp extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (this.props.open !== prevProps.open) {
-      const status = this.props.tableData.tableStatus;
-      let isSeatable;
-      if (status === 0) {
-        isSeatable = true;
-      }
-      if (status > 0) {
-        isSeatable = false;
-      }
       this.setState({
-        isOpen: this.props.open,
-        isSeatable: isSeatable
+        isOpen: this.props.open
       });
     }
   }
@@ -44,7 +34,8 @@ export default class TablePopUp extends React.Component {
   }
 
   render() {
-    const { tableId, tableStatus } = this.props.tableData;
+    let { tableId, tableStatus } = this.props.tableData;
+    tableStatus = parseInt(tableStatus, 0);
     let seatState;
     switch (tableStatus) {
       case (0):
@@ -58,14 +49,14 @@ export default class TablePopUp extends React.Component {
         break;
       default:
     }
-    let seatButtonId;
-    let seatButtonText;
-    if (this.state.isSeatable) {
-      seatButtonId = 'seat';
-      seatButtonText = `Seat Table #${tableId}`;
+    let buttonId;
+    let buttonText;
+    if (tableStatus === 0) {
+      buttonId = 'seat';
+      buttonText = `Seat Table #${tableId}`;
     } else {
-      seatButtonId = 'unseat';
-      seatButtonText = `Empty Table #${tableId}`;
+      buttonId = 'view-order';
+      buttonText = `View Order for Table #${tableId}`;
     }
     return (
       <Dialog
@@ -73,17 +64,9 @@ export default class TablePopUp extends React.Component {
         onClose={this.handleClose}
       >
         <DialogTitle>{`Table #${tableId} is ${seatState}`}</DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            Would you like to:
-          </DialogContentText>
-        </DialogContent>
         <DialogActions>
-          <Button onClick={this.handleClick} color="primary" id={seatButtonId}>
-            {seatButtonText}
-          </Button>
-          <Button onClick={this.handleClick} color="primary" id="view-order">
-            {`View order for Table #${tableId}`}
+          <Button onClick={this.handleClick} color="primary" id={buttonId}>
+            {buttonText}
           </Button>
         </DialogActions>
       </Dialog>

--- a/client/components/TablePopUp.jsx
+++ b/client/components/TablePopUp.jsx
@@ -30,7 +30,18 @@ export default class TablePopUp extends React.Component {
 
   handleClick(e) {
     const id = e.currentTarget.id;
-    console.log('id', id);
+    const { tableId } = this.props.tableData;
+    if (id === 'seat') {
+      console.log('changing table status');
+      this.props.changeTableStatus(tableId, 1);
+      this.handleClose();
+      return;
+    }
+    if (id === 'view-order') {
+      console.log('no view order functionality yet');
+
+    }
+
   }
 
   render() {

--- a/client/components/TablePopUp.jsx
+++ b/client/components/TablePopUp.jsx
@@ -18,6 +18,14 @@ export default class TablePopUp extends React.Component {
 
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.open !== prevProps.open) {
+      this.setState({
+        isOpen: this.props.open
+      });
+    }
+  }
+
   render() {
     return (
       <Dialog

--- a/client/components/TablePopUp.jsx
+++ b/client/components/TablePopUp.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
+
+export default class TablePopUp extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleClose = this.handleClose.bind(this);
+    this.state = {
+      isOpen: false
+    };
+  }
+
+  handleClose() {
+
+  }
+
+  render() {
+    return (
+      <Dialog
+        open={this.state.isOpen}
+        onClose={this.handleClose}
+      >
+        <DialogTitle>Hello there</DialogTitle>
+      </Dialog>
+    );
+  }
+}

--- a/client/components/TablePopUp.jsx
+++ b/client/components/TablePopUp.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Button from '@material-ui/core/Button';
 import Dialog from '@material-ui/core/Dialog';
 import DialogContent from '@material-ui/core/DialogContent';
+import DialogActions from '@material-ui/core/DialogActions';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 
@@ -9,30 +10,82 @@ export default class TablePopUp extends React.Component {
   constructor(props) {
     super(props);
     this.handleClose = this.handleClose.bind(this);
+    this.handleClick = this.handleClick.bind(this);
     this.state = {
-      isOpen: false
+      isOpen: false,
+      isSeatable: true
     };
   }
 
   handleClose() {
-
+    this.props.viewDialog(false, this.props.tableData);
   }
 
   componentDidUpdate(prevProps) {
     if (this.props.open !== prevProps.open) {
+      const status = this.props.tableData.tableStatus;
+      let isSeatable;
+      if (status === 0) {
+        isSeatable = true;
+      }
+      if (status > 0) {
+        isSeatable = false;
+      }
       this.setState({
-        isOpen: this.props.open
+        isOpen: this.props.open,
+        isSeatable: isSeatable
       });
     }
   }
 
+  handleClick(e) {
+    const id = e.currentTarget.id;
+    console.log('id', id);
+  }
+
   render() {
+    const { tableId, tableStatus } = this.props.tableData;
+    let seatState;
+    switch (tableStatus) {
+      case (0):
+        seatState = 'Empty';
+        break;
+      case (1):
+        seatState = 'Seated';
+        break;
+      case (2):
+        seatState = 'Billed';
+        break;
+      default:
+    }
+    let seatButtonId;
+    let seatButtonText;
+    if (this.state.isSeatable) {
+      seatButtonId = 'seat';
+      seatButtonText = `Seat Table #${tableId}`;
+    } else {
+      seatButtonId = 'unseat';
+      seatButtonText = `Empty Table #${tableId}`;
+    }
     return (
       <Dialog
         open={this.state.isOpen}
         onClose={this.handleClose}
       >
-        <DialogTitle>Hello there</DialogTitle>
+        <DialogTitle>{`Table #${tableId} is ${seatState}`}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Would you like to:
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={this.handleClick} color="primary" id={seatButtonId}>
+            {seatButtonText}
+          </Button>
+          <Button onClick={this.handleClick} color="primary" id="view-order">
+            {`View order for Table #${tableId}`}
+          </Button>
+        </DialogActions>
       </Dialog>
     );
   }

--- a/client/components/TablePopUp.jsx
+++ b/client/components/TablePopUp.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import Button from '@material-ui/core/Button';
 import Dialog from '@material-ui/core/Dialog';
-import DialogContent from '@material-ui/core/DialogContent';
 import DialogActions from '@material-ui/core/DialogActions';
-import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 
 export default class TablePopUp extends React.Component {
@@ -32,13 +30,12 @@ export default class TablePopUp extends React.Component {
     const id = e.currentTarget.id;
     const { tableId } = this.props.tableData;
     if (id === 'seat') {
-      console.log('changing table status');
       this.props.changeTableStatus(tableId, 1);
       this.handleClose();
       return;
     }
     if (id === 'view-order') {
-      console.log('no view order functionality yet');
+      console.error('no view order functionality yet');
 
     }
 

--- a/client/components/ViewRestaurant.jsx
+++ b/client/components/ViewRestaurant.jsx
@@ -13,6 +13,7 @@ export default class ViewRestaurant extends React.Component {
   constructor(props) {
     super(props);
     this.viewDialog = this.viewDialog.bind(this);
+    this.changeTableStatus = this.changeTableStatus.bind(this);
     this.state = {
       dialogOpen: false,
       tableData: {}
@@ -28,6 +29,20 @@ export default class ViewRestaurant extends React.Component {
     });
   }
 
+  changeTableStatus(tableId, newStatus) {
+    newStatus = { newStatus: newStatus };
+    fetch(`/api/restaurant/${tableId}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(newStatus)
+    })
+      .then(response => {
+        console.log('this should update after');
+      });
+  }
+
   render() {
     let { path, url } = this.props.match;
     path = path.replace(/\/$/, '');
@@ -38,6 +53,7 @@ export default class ViewRestaurant extends React.Component {
           open={this.state.dialogOpen}
           tableData={this.state.tableData}
           viewDialog={this.viewDialog}
+          changeTableStatus={this.changeTableStatus}
         />
         <Box display="flex">
           <ViewChecks url={url} />

--- a/client/components/ViewRestaurant.jsx
+++ b/client/components/ViewRestaurant.jsx
@@ -13,20 +13,35 @@ export default class ViewRestaurant extends React.Component {
   constructor(props) {
     super(props);
     this.viewDialog = this.viewDialog.bind(this);
+    this.updateTables = this.updateTables.bind(this);
     this.changeTableStatus = this.changeTableStatus.bind(this);
     this.state = {
+      floorPlan: [],
       dialogOpen: false,
       tableData: {}
     };
   }
 
   viewDialog(dialogOpen, tableData) {
-    console.log('Dialog Viewed');
-    console.log(tableData, 'params work too');
     this.setState({
       dialogOpen: dialogOpen,
       tableData: tableData
     });
+  }
+
+  componentDidMount() {
+    this.updateTables();
+  }
+
+  updateTables() {
+    fetch('/api/restaurant')
+      .then(response => response.json())
+      .then(data => {
+        this.setState({ floorPlan: data });
+      })
+      .catch(error => {
+        console.error(error);
+      });
   }
 
   changeTableStatus(tableId, newStatus) {
@@ -39,7 +54,7 @@ export default class ViewRestaurant extends React.Component {
       body: JSON.stringify(newStatus)
     })
       .then(response => {
-        console.log('this should update after');
+        this.updateTables();
       });
   }
 
@@ -62,7 +77,7 @@ export default class ViewRestaurant extends React.Component {
             <Route
               exact path={path}
               render={props => (
-                <FloorPlan {...props} viewDialog={this.viewDialog} dialogOpen={this.state.dialogOpen}/>
+                <FloorPlan {...props} floorPlan={this.state.floorPlan} viewDialog={this.viewDialog} dialogOpen={this.state.dialogOpen}/>
               )}
             />
           </Switch>

--- a/client/components/ViewRestaurant.jsx
+++ b/client/components/ViewRestaurant.jsx
@@ -10,6 +10,19 @@ import {
 } from 'react-router-dom';
 
 export default class ViewRestaurant extends React.Component {
+  constructor(props) {
+    super(props);
+    this.viewDialog = this.viewDialog.bind(this);
+    this.state = {
+      dialogOpen: false
+    };
+  }
+
+  viewDialog(params) {
+    this.setState({
+      dialogOpen: params
+    });
+  }
 
   render() {
     let { path, url } = this.props.match;
@@ -22,7 +35,12 @@ export default class ViewRestaurant extends React.Component {
         <ViewChecks url={url} />
         <Switch>
           <Route path={`${path}/checkitem/:checkId/:tableId`} component={ViewCheckItem} />
-          <Route exact path={path} component={FloorPlan} />
+          <Route
+            exact path={path}
+            render={props => (
+              <FloorPlan {...props} viewDialog={this.viewDialog} dialogOpen={this.state.dialogOpen}/>
+            )}
+          />
         </Switch>
 
       </Box>

--- a/client/components/ViewRestaurant.jsx
+++ b/client/components/ViewRestaurant.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import Box from '@material-ui/core/Box';
-
 import FloorPlan from './FloorPlan';
 import ViewChecks from './ViewChecks';
 import ViewCheckItem from './ViewCheckItem';
+import TablePopUp from './TablePopUp';
 import {
   Switch,
   Route
@@ -14,13 +14,17 @@ export default class ViewRestaurant extends React.Component {
     super(props);
     this.viewDialog = this.viewDialog.bind(this);
     this.state = {
-      dialogOpen: false
+      dialogOpen: false,
+      tableData: {}
     };
   }
 
-  viewDialog(params) {
+  viewDialog(dialogOpen, tableData) {
+    console.log('Dialog Viewed');
+    console.log(tableData, 'params work too');
     this.setState({
-      dialogOpen: params
+      dialogOpen: dialogOpen,
+      tableData: tableData
     });
   }
 
@@ -29,21 +33,21 @@ export default class ViewRestaurant extends React.Component {
     path = path.replace(/\/$/, '');
     url = url.replace(/\/$/, '');
     return (
-
-      <Box display="flex">
-
-        <ViewChecks url={url} />
-        <Switch>
-          <Route path={`${path}/checkitem/:checkId/:tableId`} component={ViewCheckItem} />
-          <Route
-            exact path={path}
-            render={props => (
-              <FloorPlan {...props} viewDialog={this.viewDialog} dialogOpen={this.state.dialogOpen}/>
-            )}
-          />
-        </Switch>
-
-      </Box>
+      <>
+        <TablePopUp open={this.state.dialogOpen} tableData={this.state.tableData} />
+        <Box display="flex">
+          <ViewChecks url={url} />
+          <Switch>
+            <Route path={`${path}/checkitem/:checkId/:tableId`} component={ViewCheckItem} />
+            <Route
+              exact path={path}
+              render={props => (
+                <FloorPlan {...props} viewDialog={this.viewDialog} dialogOpen={this.state.dialogOpen}/>
+              )}
+            />
+          </Switch>
+        </Box>
+      </>
     );
   }
 }

--- a/client/components/ViewRestaurant.jsx
+++ b/client/components/ViewRestaurant.jsx
@@ -34,7 +34,11 @@ export default class ViewRestaurant extends React.Component {
     url = url.replace(/\/$/, '');
     return (
       <>
-        <TablePopUp open={this.state.dialogOpen} tableData={this.state.tableData} />
+        <TablePopUp
+          open={this.state.dialogOpen}
+          tableData={this.state.tableData}
+          viewDialog={this.viewDialog}
+        />
         <Box display="flex">
           <ViewChecks url={url} />
           <Switch>


### PR DESCRIPTION
Functionality for viewing order is not there yet but user can seat table.  This does not provide functionality for unseating or changing status to billed.  It will be easy to add, but we need to decide where that happens.

![captured (2)](https://user-images.githubusercontent.com/61432718/89957631-c01b4980-dbec-11ea-84d4-06ea976a60da.gif)

This function in ViewRestaurant.jsx will need to be used elsewhere, best just to copy and modify it.  updateTables doesn't need to be called on other components:

![image](https://user-images.githubusercontent.com/61432718/89957711-f658c900-dbec-11ea-8308-f3297b3192c9.png)

Routing for view-order should go where the console.error is currently:

![image](https://user-images.githubusercontent.com/61432718/89957742-0d97b680-dbed-11ea-995d-0d3354a313c0.png)

Floorplan updateTables has been moved up to view restaurant.  tableData stores the last clicked table on the floorplan, in case we want to use that somehow.

![image](https://user-images.githubusercontent.com/61432718/89957909-83038700-dbed-11ea-959f-e19d92e16a1a.png)

TableButton and FloorPlan have also been renovated.

